### PR TITLE
Fix/writer api

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ writer = Wavefront::Writer.new({:agent_host => 'agent.local.com', :host_name => 
 # value of the metric at current timestamp is: 5
 writer.write(5)
 # Let's write a different metric overwriting the default options from the constructor
-writer.write(6, 'namespace.my.other.metric', {host: 'server2'})
+writer.write(6, 'namespace.my.other.metric', {host_name: 'server2'})
 ```
 
 * The initializer takes a hash of options, wherein one can set

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ writer = Wavefront::Writer.new({:agent_host => 'agent.local.com', :host_name => 
 # value of the metric at current timestamp is: 5
 writer.write(5)
 # Let's write a different metric overwriting the default options from the constructor
-writer.write(6, 'namespace.my.other.metric', 'server2', {})
+writer.write(6, 'namespace.my.other.metric', {host: 'server2'})
 ```
 
 * The initializer takes a hash of options, wherein one can set
@@ -32,9 +32,17 @@ writer.write(6, 'namespace.my.other.metric', 'server2', {})
   * The write method parameters are:
     * `metric_value` - A number, the value of the metric reporting at the current timestamp
     * `metric_name` - A `String`, this must be present, either within the write method call or set on the Writer class
-    * `host_name` - A `String`, which will appear as the host for the sent metric in Wavefront. 
-    * `point_tags` - A `Map` of key, value pairs of strings which will be sent to Wavefront. Not required. Note that if you specify these as part of the write method call they replace any set at the class level. The two maps are _not_ merged.
-    * `timestamp` - The Epoch Seconds of the reported point. Default: `Time.now`
+    * A hash of options:
+      * `host_name` - A `String`, which will appear as the host for the sent
+         metric in Wavefront. Defaults to the `host_name` used to initialize
+         the class.
+      * `point_tags` - A `Map` of key, value pairs of strings which will be
+        sent to Wavefront. Not required. Note that if you specify these as
+        part of the write method call they replace any set at the class level.
+        The two maps are _not_ merged. Defaults to the `point_tags` used to
+        initialize the class
+      * `timestamp` - The Epoch Seconds (`Fixnum`), or a Ruby `Time` object, of
+        the reported point Default: `Time.now`
 
 ### Host Tags
 
@@ -52,13 +60,13 @@ meta.add_tags(["host.server1.server.com","host.server2.server.com"],["tag1","tag
 meta.remove_tags(["server1.server.com","server2.server.com"],["tag1","tag2"]) # Remove an arbitrary number of tags from an arbitrary number of hosts
 ```
 
-* The initializer takes up to 3 parameters: 
+* The initializer takes up to 3 parameters:
   * `token`              - A valid Wavefront API Token. This is required.
   * `host`               - A `String` representing the Wavefront endpoint to connect to. Default: `metrics.wavefront.com`.
   * `debug` `true|false` - When set to `true` output `RestClient` debugging to `stdout`. Default: `false`.
 
 ### Query Client
-  
+
 The `Wavefront::Client` class can be used to send queries to Wavefront and get a response
 
 Example usage:
@@ -72,7 +80,7 @@ response = wave.query('<TS_EXPRESSION>')  # <TS_EXPRESSION> : Placeholder for a 
 response = wave.query('<TS_EXPRESSION>', 'm', {:start_time => Time.now - 86400, :end_time => Time.now})  # <TS_EXPRESSION> : Placeholder for a valid Wavefront ts() query
 ```
 
-* Like the Metadata class, the initializer takes up to 3 parameters: 
+* Like the Metadata class, the initializer takes up to 3 parameters:
   * `token`              - A valid Wavefront API Token. This is required.
   * `host`               - A `String` representing the Wavefront endpoint to connect to. Default: `metrics.wavefront.com`.
   * `debug` `true|false` - When set to `true` output `RestClient` debugging to `stdout`. Default: `false`.
@@ -105,7 +113,7 @@ response.class  # Wavefront::Response::Raw
 response = wave.query('<TS_EXPRESSION>', 'm', {:response_format => :ruby}) # <TS_EXPRESSION> : Placeholder for a valid Wavefront ts() query
 response.class # Wavefront::Response::Ruby
 response.instance_variables  # [:@response, :@query, :@name, :@timeseries, :@stats]
-response.query  
+response.query
 ```
 
 * `:response_format => :graphite`

--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "0.5.3"
+    VERSION = "0.5.4"
   end
 end

--- a/lib/wavefront/writer.rb
+++ b/lib/wavefront/writer.rb
@@ -40,7 +40,7 @@ module Wavefront
     end
 
     def write(metric_value, metric_name = @metric_name, options = {})
-      options[:host] ||= @host_name
+      options[:host_name] ||= @host_name
       options[:point_tags] ||= @point_tags
       options[:timestamp] ||= Time.now
 
@@ -49,10 +49,10 @@ module Wavefront
       end
 
       if options[:point_tags].empty?
-        append = "host=#{options[:host]}"
+        append = "host=#{options[:host_name]}"
       else
         tags = options[:point_tags].map { |k, v| "#{k}=\"#{v}\"" }.join(' ')
-        append = "host=#{options[:host]} #{tags}"
+        append = "host=#{options[:host_name]} #{tags}"
       end
 
       @socket.puts [metric_name, metric_value, options[:timestamp].to_i,

--- a/lib/wavefront/writer.rb
+++ b/lib/wavefront/writer.rb
@@ -1,4 +1,4 @@
-=begin 
+=begin
     Copyright 2015 Wavefront Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,23 +31,37 @@ module Wavefront
       options[:host_name] ||= DEFAULT_HOSTNAME
       options[:metric_name] ||= ''
       options[:point_tags] ||= {}
-      
+
       @host_name = options[:host_name]
       @metric_name = options[:metric_name]
       @point_tags = options[:point_tags]
-      
+
       @socket = get_socket(options[:agent_host], options[:agent_port])
     end
-    
-    def write(metric_value, metric_name=@metric_name, host=@host_name, point_tags=@point_tags, timestamp=Time.now)
-      raise Wavefront::Exception::EmptyMetricName if metric_name.empty?
-      tags = point_tags.empty? ? '' : point_tags.map{|k,v| "#{k}=\"#{v}\""}.join(' ')
-      append = tags.empty? ? "host=#{host}" : "host=#{host} #{tags}"
-      @socket.puts "#{metric_name} #{metric_value} #{timestamp.to_i} #{append}"
+
+    def write(metric_value, metric_name = @metric_name, options = {})
+      options[:host] ||= @host_name
+      options[:point_tags] ||= @point_tags
+      options[:timestamp] ||= Time.now
+
+      if metric_name.empty?
+        raise Wavefront::Exception::EmptyMetricName
+      end
+
+      if options[:point_tags].empty?
+        append = "host=#{options[:host]}"
+      else
+        tags = options[:point_tags].map { |k, v| "#{k}=\"#{v}\"" }.join(' ')
+        append = "host=#{options[:host]} #{tags}"
+      end
+
+      @socket.puts [metric_name, metric_value, options[:timestamp].to_i,
+                    append].join(' ')
     end
 
     private
-    def get_socket(host,port)
+
+    def get_socket(host, port)
       TCPSocket.new(host, port)
     end
 

--- a/spec/wavefront/writer_spec.rb
+++ b/spec/wavefront/writer_spec.rb
@@ -1,4 +1,4 @@
-=begin 
+=begin
     Copyright 2015 Wavefront Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -28,11 +28,11 @@ describe Wavefront::Writer do
 
   it 'has some defaults' do
     expect(Wavefront::Writer::DEFAULT_HOST).to_not be_nil
-    expect(Wavefront::Writer::DEFAULT_HOST).to be_a_kind_of String 
+    expect(Wavefront::Writer::DEFAULT_HOST).to be_a_kind_of String
     expect(Wavefront::Writer::DEFAULT_PORT).to_not be_nil
-    expect(Wavefront::Writer::DEFAULT_PORT).to be_a_kind_of Fixnum 
+    expect(Wavefront::Writer::DEFAULT_PORT).to be_a_kind_of Fixnum
     expect(Wavefront::Writer::DEFAULT_HOSTNAME).to_not be_nil
-    expect(Wavefront::Writer::DEFAULT_HOSTNAME).to be_a_kind_of String 
+    expect(Wavefront::Writer::DEFAULT_HOSTNAME).to be_a_kind_of String
   end
 
 
@@ -62,9 +62,9 @@ describe Wavefront::Writer do
       allow(Time).to receive(:now).and_return(123456789)
       expect(socket).to receive(:puts).with("metric 50 123456789 host=somehost")
       writer = Wavefront::Writer.new
-      writer.write(50, "metric", host, {}, 123456789)
+      writer.write(50, "metric", {host: host, timestamp: 123456789})
     end
-    
+
     it 'should accept a single tag and append it correctly' do
       host = 'somehost'
       port = '8566'
@@ -74,7 +74,8 @@ describe Wavefront::Writer do
       allow(Time).to receive(:now).and_return(123456789)
       expect(socket).to receive(:puts).with("metric 50 123456789 host=somehost tag_key_one=\"tag_val_one\"")
       writer = Wavefront::Writer.new
-      writer.write(50, "metric", host, tags, 123456789)
+      writer.write(50, "metric",
+                   {host: host, point_tags: tags, timestamp: 123456789})
     end
 
    it 'should accept multiple tags and append them correctly' do
@@ -86,9 +87,9 @@ describe Wavefront::Writer do
       allow(Time).to receive(:now).and_return(123456789)
       expect(socket).to receive(:puts).with("metric 50 123456789 host=somehost tag_key_one=\"tag_val_one\" k2=\"v2\"")
       writer = Wavefront::Writer.new
-      writer.write(50, "metric", host, tags, 123456789)
+      writer.write(50, "metric",
+                   {host: host, point_tags: tags, timestamp: 123456789})
 
    end
   end
-
 end

--- a/spec/wavefront/writer_spec.rb
+++ b/spec/wavefront/writer_spec.rb
@@ -62,7 +62,7 @@ describe Wavefront::Writer do
       allow(Time).to receive(:now).and_return(123456789)
       expect(socket).to receive(:puts).with("metric 50 123456789 host=somehost")
       writer = Wavefront::Writer.new
-      writer.write(50, "metric", {host: host, timestamp: 123456789})
+      writer.write(50, "metric", {host_name: host, timestamp: 123456789})
     end
 
     it 'should accept a single tag and append it correctly' do
@@ -75,7 +75,7 @@ describe Wavefront::Writer do
       expect(socket).to receive(:puts).with("metric 50 123456789 host=somehost tag_key_one=\"tag_val_one\"")
       writer = Wavefront::Writer.new
       writer.write(50, "metric",
-                   {host: host, point_tags: tags, timestamp: 123456789})
+                   {host_name: host, point_tags: tags, timestamp: 123456789})
     end
 
    it 'should accept multiple tags and append them correctly' do
@@ -88,7 +88,7 @@ describe Wavefront::Writer do
       expect(socket).to receive(:puts).with("metric 50 123456789 host=somehost tag_key_one=\"tag_val_one\" k2=\"v2\"")
       writer = Wavefront::Writer.new
       writer.write(50, "metric",
-                   {host: host, point_tags: tags, timestamp: 123456789})
+                   {host_name: host, point_tags: tags, timestamp: 123456789})
 
    end
   end


### PR DESCRIPTION
The writer method's arguments are, IMO, in the wrong order. The Timestamp needs to be easily accessible, and the way it was written, this is not the case. The rest of the API uses an options hash for all optional parameters, and I have changed writer to follow this pattern.

This is a breaking change to anyone who used more than two arguments to the writer API, so I understand this PR may be rejected for that reason. It may also require a greater change to the version number than I have made here. I leave this to the owner's discretion.