### PR TITLE
fix type exception

### DIFF
--- a/bin/wavefront-client
+++ b/bin/wavefront-client
@@ -46,11 +46,11 @@ end
 
 options = Hash.new
 if @opts[:start]
-  options[:start_time] = @opts[:start]
+  options[:start_time] = Time.at(@opts[:start].to_i)
 end
 
 if @opts[:end]
-  options[:end_time] = @opts[:end]
+  options[:end_time] = Time.at(@opts[:end].to_i)
 end
 
 wave = Wavefront::Client.new(@opts[:token])

--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "0.5.3"
+    VERSION = "0.5.4"
   end
 end


### PR DESCRIPTION
When using the `wavefront-client` CLI and specifying `--start` and/or `--end` times the following exception is thrown:

```
/home/sam/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/wavefront-client-0.5.2/lib/wavefront/client.rb:44:in `query': undefined method `-' for "1439372646":String (NoMethodError)
        from /home/sam/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/wavefront-client-0.5.2/bin/wavefront-client:57:in `<top (required)>'
        from /home/sam/.rbenv/versions/2.2.2/bin/wavefront-client:23:in `load'
        from /home/sam/.rbenv/versions/2.2.2/bin/wavefront-client:23:in `<main>'
```
This PR corrects that by ensuring that the options are cast to the correct types before the ``Wavefront::Client`` object instantiation.