### PR TITLE
Query alternative endpoints

### DIFF
--- a/bin/wavefront-client
+++ b/bin/wavefront-client
@@ -23,8 +23,8 @@ require 'json'
   on 'd', 'days', 'Query granularity of days'
   on 'D', 'debug', 'Enable debug mode'
   on 'm', 'minutes', 'Query granularity of minutes'
-  on 'h', 'hours', 'Query granularity of hours'
-  on 'H', 'host=', 'Connect to alternative cluster host', default: Wavefront::Client::DEFAULT_HOST.to_s
+  on 'H', 'hours', 'Query granularity of hours'
+  on 'e', 'endpoint=', 'Connect to alternative cluster endpoint', default: Wavefront::Client::DEFAULT_HOST.to_s
   on 'S', 'seconds', 'Query granularity of seconds'
   on 's', 'start=', 'Time in UNIX epoch seconds to begin the query from'
   on 't', 'token=', 'Wavefront authentication token'
@@ -43,7 +43,7 @@ query = ARGV[0]
 if @opts.minutes?
   granularity = 'm'
 elsif @opts.hours?
-  granularity = 'h'
+  granularity = 'H'
 elsif @opts.seconds?
   granularity = 's'
 elsif @opts.days?
@@ -70,7 +70,7 @@ if @opts[:end]
   options[:end_time] = Time.at(@opts[:end].to_i)
 end
 
-wave = Wavefront::Client.new(@opts[:token], @opts[:host], @opts[:debug])
+wave = Wavefront::Client.new(@opts[:token], @opts[:endpoint], @opts[:debug])
 case options[:response_format]
 when :raw
   puts wave.query(query, granularity, options)

--- a/bin/wavefront-client
+++ b/bin/wavefront-client
@@ -43,7 +43,7 @@ query = ARGV[0]
 if @opts.minutes?
   granularity = 'm'
 elsif @opts.hours?
-  granularity = 'H'
+  granularity = 'h'
 elsif @opts.seconds?
   granularity = 's'
 elsif @opts.days?

--- a/bin/wavefront-client
+++ b/bin/wavefront-client
@@ -24,7 +24,7 @@ require 'json'
   on 'D', 'debug', 'Enable debug mode'
   on 'm', 'minutes', 'Query granularity of minutes'
   on 'H', 'hours', 'Query granularity of hours'
-  on 'e', 'endpoint=', 'Connect to alternative cluster endpoint', default: Wavefront::Client::DEFAULT_HOST.to_s
+  on 'E', 'endpoint=', 'Connect to alternative cluster endpoint', default: Wavefront::Client::DEFAULT_HOST.to_s
   on 'S', 'seconds', 'Query granularity of seconds'
   on 's', 'start=', 'Time in UNIX epoch seconds to begin the query from'
   on 't', 'token=', 'Wavefront authentication token'

--- a/bin/wavefront-client
+++ b/bin/wavefront-client
@@ -20,8 +20,11 @@ require 'json'
 
 @opts = Slop.parse(strict: true) do
   banner 'Usage: wavefront-client QUERY (OPTIONS)'
+  on 'd', 'days', 'Query granularity of days'
+  on 'D', 'debug', 'Enable debug mode'
   on 'm', 'minutes', 'Query granularity of minutes'
   on 'h', 'hours', 'Query granularity of hours'
+  on 'H', 'host=', 'Connect to alternative cluster host', default: Wavefront::Client::DEFAULT_HOST.to_s
   on 'S', 'seconds', 'Query granularity of seconds'
   on 's', 'start=', 'Time in UNIX epoch seconds to begin the query from'
   on 't', 'token=', 'Wavefront authentication token'
@@ -43,8 +46,10 @@ elsif @opts.hours?
   granularity = 'h'
 elsif @opts.seconds?
   granularity = 's'
+elsif @opts.days?
+  granularity = 'd'
 else
-  puts "You must specify a granularity of either --seconds, --minutes or --hours. See --help for more information."
+  puts "You must specify a granularity of either --seconds, --minutes --hours or --days. See --help for more information."
   exit 1
 end
 
@@ -65,7 +70,7 @@ if @opts[:end]
   options[:end_time] = Time.at(@opts[:end].to_i)
 end
 
-wave = Wavefront::Client.new(@opts[:token])
+wave = Wavefront::Client.new(@opts[:token], @opts[:host], @opts[:debug])
 case options[:response_format]
 when :raw
   puts wave.query(query, granularity, options)

--- a/lib/wavefront/alerting.rb
+++ b/lib/wavefront/alerting.rb
@@ -16,13 +16,14 @@ See the License for the specific language governing permissions and
 
 require "wavefront/client/version"
 require "wavefront/exception"
+require "wavefront/constants"
 require 'rest_client'
 require 'uri'
 require 'logger'
 
 module Wavefront
   class Alerting
-    DEFAULT_HOST = 'metrics.wavefront.com'
+    include Wavefront::Constants
     DEFAULT_PATH = '/api/alert/'
 
     attr_reader :token

--- a/lib/wavefront/client.rb
+++ b/lib/wavefront/client.rb
@@ -24,13 +24,6 @@ require 'logger'
 
 module Wavefront
   class Client
-    DEFAULT_PERIOD_SECONDS = 600
-    DEFAULT_PATH = '/chart/api'
-    DEFAULT_FORMAT = :raw
-    DEFAULT_PREFIX_LENGTH = 1
-    DEFAULT_STRICT = true
-    FORMATS = [ :raw, :ruby, :graphite, :highcharts ]
-    GRANULARITIES = %w( s m h d )
 
     attr_reader :headers, :base_uri
 

--- a/lib/wavefront/client.rb
+++ b/lib/wavefront/client.rb
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 =end
 
 require "wavefront/client/version"
-require "wavefront/client/constants"
+require "wavefront/constants"
 require "wavefront/exception"
 require "wavefront/response"
 require 'rest_client'
@@ -24,6 +24,9 @@ require 'logger'
 
 module Wavefront
   class Client
+
+    include Wavefront::Constants
+    DEFAULT_PATH = '/chart/api'
 
     attr_reader :headers, :base_uri
 

--- a/lib/wavefront/client/constants.rb
+++ b/lib/wavefront/client/constants.rb
@@ -15,3 +15,10 @@ See the License for the specific language governing permissions and
 =end
 
 DEFAULT_HOST = 'metrics.wavefront.com'
+DEFAULT_PERIOD_SECONDS = 600
+DEFAULT_PATH = '/chart/api'
+DEFAULT_FORMAT = :raw
+DEFAULT_PREFIX_LENGTH = 1
+DEFAULT_STRICT = true
+FORMATS = [ :raw, :ruby, :graphite, :highcharts ]
+GRANULARITIES = %w( s m h d )

--- a/lib/wavefront/client/constants.rb
+++ b/lib/wavefront/client/constants.rb
@@ -14,11 +14,15 @@ See the License for the specific language governing permissions and
 
 =end
 
-DEFAULT_HOST = 'metrics.wavefront.com'
-DEFAULT_PERIOD_SECONDS = 600
-DEFAULT_PATH = '/chart/api'
-DEFAULT_FORMAT = :raw
-DEFAULT_PREFIX_LENGTH = 1
-DEFAULT_STRICT = true
-FORMATS = [ :raw, :ruby, :graphite, :highcharts ]
-GRANULARITIES = %w( s m h d )
+module Wavefront
+  class Client
+    DEFAULT_HOST = 'metrics.wavefront.com'
+    DEFAULT_PERIOD_SECONDS = 600
+    DEFAULT_PATH = '/chart/api'
+    DEFAULT_FORMAT = :raw
+    DEFAULT_PREFIX_LENGTH = 1
+    DEFAULT_STRICT = true
+    FORMATS = [ :raw, :ruby, :graphite, :highcharts ]
+    GRANULARITIES = %w( s m h d )
+  end
+end

--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "1.2.0"
+    VERSION = "2.0.0"
   end
 end

--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "1.1.1"
+    VERSION = "1.2.0"
   end
 end

--- a/lib/wavefront/constants.rb
+++ b/lib/wavefront/constants.rb
@@ -15,10 +15,9 @@ See the License for the specific language governing permissions and
 =end
 
 module Wavefront
-  class Client
+  module Constants
     DEFAULT_HOST = 'metrics.wavefront.com'
     DEFAULT_PERIOD_SECONDS = 600
-    DEFAULT_PATH = '/chart/api'
     DEFAULT_FORMAT = :raw
     DEFAULT_PREFIX_LENGTH = 1
     DEFAULT_STRICT = true

--- a/lib/wavefront/events.rb
+++ b/lib/wavefront/events.rb
@@ -3,6 +3,7 @@ require_relative 'exception'
 require 'rest_client'
 require 'uri'
 require 'logger'
+require 'wavefront/constants'
 #
 # Add basic support to cover Wavefront's events API. I have followed
 # the standards and conventions established in the files already in
@@ -17,7 +18,7 @@ module Wavefront
   # the event', 's' as 'start time for the event' and so-on.
   #
   class Events
-    DEFAULT_HOST = 'metrics.wavefront.com'
+    include Wavefront::Constants
     DEFAULT_PATH = '/api/events/'
 
     attr_reader :token

--- a/lib/wavefront/metadata.rb
+++ b/lib/wavefront/metadata.rb
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 =end
 
 require "wavefront/client/version"
-require "wavefront/client/constants"
+require "wavefront/constants"
 require "wavefront/exception"
 require 'rest_client'
 require 'uri'
@@ -23,6 +23,7 @@ require 'logger'
 
 module Wavefront
   class Metadata
+    include Wavefront::Constants
     DEFAULT_PATH = '/api/manage/source/'
 
     attr_reader :headers, :base_uri

--- a/lib/wavefront/writer.rb
+++ b/lib/wavefront/writer.rb
@@ -16,11 +16,13 @@ See the License for the specific language governing permissions and
 
 require "wavefront/client/version"
 require "wavefront/exception"
+require "wavefront/constants"
 require 'uri'
 require 'socket'
 
 module Wavefront
   class Writer
+    include Wavefront::Constants
     DEFAULT_AGENT_HOST = 'localhost'
     DEFAULT_PORT = 2878
     DEFAULT_HOSTNAME = %x{hostname -f}.chomp


### PR DESCRIPTION
The functional change in this PR is to allow the expression of an alternative cluster endpoint name in the CLI (allowing queries against private clusters). I've also tidied up some of the switch usage and brokenness - some of the short switches were duplicated (-h for "hours" and "help", for example).

As part of this I have also canonicalized the common constants into a new `Wavefront::Constants` module, and mixed that into the pertinent classes; I did this primarily to remove duplication of `DEFAULT_HOST`, in keeping with the theme of this changeset.

I bumped the version to 2.0.0 as, strictly speaking, I've broken (or rather created!) the constants interface and CLI switch interface. In practice code using `Wavefront::Client` and the like will experience no breaking changes.