### PR TITLE
Feature/config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,16 +180,18 @@ See `<command> --help` for more information on a specific command.
 
 $ wavefront ts --help
 Usage: wavefront COMMAND QUERY (OPTIONS)
-    -d, --days                        Query granularity of days
+    -c, --config                      path to configuration file (default: ${HOME}/.wavefront)
+    -P, --profile                     profile in configuration file (default: default)
     -D, --debug                       Enable debug mode
+    -S, --seconds                     Query granularity of seconds
     -m, --minutes                     Query granularity of minutes
     -H, --hours                       Query granularity of hours
-    -E, --endpoint                    Connect to alternative cluster endpoint (default: metrics.wavefront.com)
-    -S, --seconds                     Query granularity of seconds
-    -s, --start                       Time in UNIX epoch seconds to begin the query from
+    -d, --days                        Query granularity of days
+    -s, --start                       start of query window in epoch seconds or parseable format
+    -e, --end                         end of query window in epoch seconds or parseable format
     -t, --token                       Wavefront authentication token
-    -e, --end                         Time in UNIX epoch seconds to query to
-    -f, --format                      Output format (raw, ruby, graphite, highcharts) (default: raw)
+    -E, --endpoint                    Connect to alternative cluster endpoint (default: metrics.wavefront.com)
+    -f, --format                      Output format (raw, ruby, graphite, highcharts, human) (default: raw)
     -p, --prefixlength                The number of path elements to treat as a prefix when doing schema manipulations (default: 1)
     -X, --strict                      Flag to not return points outside the query window [q;s)  (default: true)
     -O, --includeObsoleteMetrics      Flag to include metrics that have not been reporting for more than 4 weeks,defaults to false
@@ -213,6 +215,55 @@ $ wavefront alerts snoozed -t TOKEN -f json --shared ops
    ...
 ```
 
+#### Notes on Options
+
+##### Times
+
+The query window can be defined by using Unix epoch times (as shown
+by `date "%+s"`) or by entering any Ruby `strptime`-parseable string.
+For instance:
+
+```bash
+$ wavefront --start 12:15 --end 12:20 ...
+```
+
+will request data points between 12:15 and 12:20pm today. If you ran
+that in the morning, the time would be invalid, and you would get a
+400 error from Wavefront, so something of the form
+`2016-04-17T12:25:00` would remove all ambiguity.
+
+There is no need to include a timezone in your parseable string: the
+`wavefront` CLI will automatically use your local timezone when it
+parses the string.
+
+#### Default Configuration
+
+Passing tokens and endpoints into the `wavefront` command can become
+tiresome, so you can put such data into an `ini`-style configuration
+file. By default this file should be located at `${HOME}/.wavefront`,
+though you can override the location with the `-c` flag.
+
+You can switch between Wavefront accounts using profile stanzas,
+selected with the `-P` option.  If `-P` is not supplied, the
+`default` profile will be used. Not having a useable configuration
+file will not cause an error.
+
+A configuration file looks like this:
+
+```
+[default]
+token = abcdefab-1234-abcd-1234-abcdefabcdef
+endpoint = companya.wavefront.com
+format = human
+
+[companyb]
+token = 12345678-abcd-0123-abcd-123456789abc
+endpoint = metrics.wavefront.com
+```
+
+The key for each key-value pair can match any long option show in the
+command `help`, so you can set, for instance, a default output
+format, as shown above.
 
 ## Building and installing
 

--- a/bin/wavefront
+++ b/bin/wavefront
@@ -12,10 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 #    limitations under the License.
-
-require 'wavefront/client'
+$LOAD_PATH.unshift('/home/rob/work/ruby-client/lib')
+$LOAD_PATH.unshift('/home/rob/work/ruby-client')
+require  'lib/wavefront/client'
 require 'slop'
 
+begin
 options = Slop.parse(strict: true) do
   banner 'Usage: wavefront COMMAND QUERY (OPTIONS)'
     on 'h', 'help', 'Display this message'
@@ -58,6 +60,10 @@ options = Slop.parse(strict: true) do
     end
   end
 
+end
+rescue Slop::InvalidOptionError => e
+  puts e
+  exit 1
 end
 
 puts options

--- a/bin/wavefront
+++ b/bin/wavefront
@@ -12,10 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 #    limitations under the License.
-$LOAD_PATH.unshift('/home/rob/work/ruby-client/lib')
-$LOAD_PATH.unshift('/home/rob/work/ruby-client')
-require  'lib/wavefront/client'
+require 'wavefront/client'
 require 'slop'
+require 'pathname'
+require 'wavefront/cli'
 
 begin
 options = Slop.parse(strict: true) do
@@ -24,24 +24,34 @@ options = Slop.parse(strict: true) do
 
   command 'ts' do
     description "Query the timeseries"
-    on 'd', 'days', 'Query granularity of days'
+    on 'c', 'config=', 'path to configuration file', default:
+                      Pathname.new(ENV['HOME']) + '.wavefront'
+    on 'P', 'profile=', 'profile in configuration file', default: 'default'
     on 'D', 'debug', 'Enable debug mode'
+    on 'S', 'seconds', 'Query granularity of seconds'
     on 'm', 'minutes', 'Query granularity of minutes'
     on 'H', 'hours', 'Query granularity of hours'
-    on 'E', 'endpoint=', 'Connect to alternative cluster endpoint', default: Wavefront::Client::DEFAULT_HOST.to_s
-    on 'S', 'seconds', 'Query granularity of seconds'
-    on 's', 'start=', 'Time in UNIX epoch seconds to begin the query from'
+    on 'd', 'days', 'Query granularity of days'
+    on 's', 'start=', 'start of query window in epoch seconds or parseable format'
+    on 'e', 'end=', 'end of query window in epoch seconds or parseable format'
     on 't', 'token=', 'Wavefront authentication token'
-    on 'e', 'end=', 'Time in UNIX epoch seconds to query to'
+    on 'E', 'endpoint=', 'Connect to alternative cluster endpoint', default: Wavefront::Client::DEFAULT_HOST.to_s
     on 'f', 'format=', "Output format (#{Wavefront::Client::FORMATS.join(', ')})", default: Wavefront::Client::DEFAULT_FORMAT.to_s
     on 'p', 'prefixlength=', 'The number of path elements to treat as a prefix when doing schema manipulations', default: Wavefront::Client::DEFAULT_PREFIX_LENGTH
     on 'X', 'strict=','Flag to not return points outside the query window [q;s) ', default: Wavefront::Client::DEFAULT_STRICT
     on 'O', 'includeObsoleteMetrics=', 'Flag to include metrics that have not been reporting for more than 4 weeks,defaults to false', default: Wavefront::Client::DEFAULT_OBSOLETE_METRICS
     on 'h', 'help', 'Display this message'
     run do |options, arguments|
+      pf_opts = Wavefront::Cli.new(options, arguments).load_profile || {}
       require 'wavefront/cli/ts'
-      cli = Wavefront::Cli::Ts.new(options, arguments)
-      cli.run
+      cli = Wavefront::Cli::Ts.new(options.to_hash.merge(pf_opts), arguments)
+      begin
+        cli.run
+      rescue => e
+        puts 'Query failed.'
+        puts e
+        exit 1
+      end
     end
   end
 

--- a/bin/wavefront
+++ b/bin/wavefront
@@ -49,7 +49,7 @@ options = Slop.parse(strict: true) do
       begin
         cli.run
       rescue => e
-        puts 'Query failed.'
+        puts 'Timeseries query failed.'
         puts e
         exit 1
       end
@@ -77,7 +77,7 @@ options = Slop.parse(strict: true) do
       begin
         cli.run
       rescue => e
-        puts 'Query failed.'
+        puts 'Alert query failed.'
         puts e
         exit 1
       end

--- a/bin/wavefront
+++ b/bin/wavefront
@@ -23,6 +23,14 @@ options = Slop.parse(strict: true) do
   banner 'Usage: wavefront COMMAND QUERY (OPTIONS)'
     on 'h', 'help', 'Display this message'
 
+  command :version do
+    description 'Display the client version and exit'
+    run do
+      puts Wavefront::Client::VERSION
+      exit 0
+    end
+  end
+
   command 'ts' do
     description "Query the timeseries"
     on 'c', 'config=', 'path to configuration file', default:
@@ -83,6 +91,8 @@ options = Slop.parse(strict: true) do
       end
     end
   end
+
+
 end
 rescue Slop::InvalidOptionError => e
   puts 'invalid option error: '+ e.to_s

--- a/bin/wavefront
+++ b/bin/wavefront
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 #    limitations under the License.
+#
 require 'wavefront/client'
 require 'slop'
 require 'pathname'
@@ -37,9 +38,9 @@ options = Slop.parse(strict: true) do
     on 't', 'token=', 'Wavefront authentication token'
     on 'E', 'endpoint=', 'Connect to alternative cluster endpoint', default: Wavefront::Client::DEFAULT_HOST.to_s
     on 'f', 'format=', "Output format (#{Wavefront::Client::FORMATS.join(', ')})", default: Wavefront::Client::DEFAULT_FORMAT.to_s
-    on 'p', 'prefixlength=', 'The number of path elements to treat as a prefix when doing schema manipulations', default: Wavefront::Client::DEFAULT_PREFIX_LENGTH
+    on 'p', 'prefixlength=', 'Number of path elements to treat as a prefix in schema manipulation', default: Wavefront::Client::DEFAULT_PREFIX_LENGTH
     on 'X', 'strict=','Flag to not return points outside the query window [q;s) ', default: Wavefront::Client::DEFAULT_STRICT
-    on 'O', 'includeObsoleteMetrics=', 'Flag to include metrics that have not been reporting for more than 4 weeks,defaults to false', default: Wavefront::Client::DEFAULT_OBSOLETE_METRICS
+    on 'O', 'includeObsoleteMetrics=', 'Include metrics which have not reported for > 4 weeks', default: Wavefront::Client::DEFAULT_OBSOLETE_METRICS
     on 'h', 'help', 'Display this message'
     run do |options, arguments|
       pf_opts = Wavefront::Cli.new(options, arguments).load_profile || {}
@@ -56,23 +57,38 @@ options = Slop.parse(strict: true) do
   end
 
   command 'alerts' do
+    banner 'Usage: wavefront alerts (OPTIONS) ALERT_STATE'
     description "Query alerts"
+    on 'c', 'config=', 'path to configuration file', default:
+                      Pathname.new(ENV['HOME']) + '.wavefront'
+    on 'P', 'profile=', 'profile in configuration file', default: 'default'
     on 'E', 'endpoint=', 'Connect to alternative cluster endpoint', default: Wavefront::Client::DEFAULT_HOST.to_s
     on 'f', 'format=', 'Output format (ruby, json)', default: 'ruby'
+    on 'f', 'format=', "Output format (#{Wavefront::Client::ALERT_FORMATS.join(', ')})", default: Wavefront::Client::DEFAULT_ALERT_FORMAT.to_s
     on 'h', 'help', 'Display this message'
     on 'p', 'private=', 'Retrieve only alerts with named private tags, comma delimited.'
     on 's', 'shared=', 'Retrieve only alerts with named shared tags, comma delimited.'
     on 't', 'token=', 'Wavefront authentication token'
     run do |options, arguments|
+      pf_opts = Wavefront::Cli.new(options, arguments).load_profile || {}
       require 'wavefront/cli/alerts'
-      cli = Wavefront::Cli::Alerts.new(options, arguments)
-      cli.run
+      cli = Wavefront::Cli::Alerts.new(options.to_hash.merge(pf_opts),
+                                       arguments)
+      begin
+        cli.run
+      rescue => e
+        puts 'Query failed.'
+        puts e
+        exit 1
+      end
     end
   end
-
 end
 rescue Slop::InvalidOptionError => e
-  puts e
+  puts 'invalid option error: '+ e.to_s
+  exit 1
+rescue Slop::MissingArgumentError => e
+  puts 'option parsing error: '+ e.to_s
   exit 1
 end
 

--- a/lib/wavefront/cli.rb
+++ b/lib/wavefront/cli.rb
@@ -1,4 +1,4 @@
-=begin 
+=begin
     Copyright 2015 Wavefront Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 
 =end
 
+require 'inifile'
+
 module Wavefront
   class Cli
 
@@ -23,9 +25,27 @@ module Wavefront
       @options   = options
       @arguments = arguments
 
-      if @options.help?
+      if @options[:help]
         puts @options
         exit 0
+      end
+    end
+
+    def load_profile
+      cf = Pathname.new(options[:config])
+      pf = options[:profile]
+
+      if cf.exist?
+        raw = IniFile.load(cf)
+        profile = raw[pf]
+
+        unless profile.empty?
+          puts "using #{pf} profile from #{cf}" if options[:debug]
+          return profile.inject({}){|x, (k, v)| x[k.to_sym] = v; x }
+        end
+
+      else
+        puts "no config file at '#{cf}': using options" if options[:debug]
       end
     end
 

--- a/lib/wavefront/cli/ts.rb
+++ b/lib/wavefront/cli/ts.rb
@@ -23,6 +23,7 @@ class Wavefront::Cli::Ts < Wavefront::Cli
   attr_accessor :options, :arguments
 
   def run
+    raise 'Please supply a query.' if @arguments.empty?
     query = @arguments[0]
 
     if @options[:minutes]
@@ -34,13 +35,11 @@ class Wavefront::Cli::Ts < Wavefront::Cli
     elsif @options[:days]
       granularity = 'd'
     else
-      puts "You must specify a granularity of either --seconds, --minutes --hours or --days. See --help for more information."
-      exit 1
+      raise "You must specify a granularity of either --seconds, --minutes --hours or --days. See --help for more information."
     end
 
     unless Wavefront::Client::FORMATS.include?(@options[:format].to_sym)
-      puts "The output format must be on of #{Wavefront::Client::FORMATS.join(', ')}"
-      exit 1
+      raise "The output format must be one of: #{Wavefront::Client::FORMATS.join(', ')}."
     end
 
     options = Hash.new

--- a/lib/wavefront/cli/ts.rb
+++ b/lib/wavefront/cli/ts.rb
@@ -17,10 +17,20 @@ require 'wavefront/client'
 require 'wavefront/cli'
 require 'pp'
 require 'json'
+require 'date'
 
 class Wavefront::Cli::Ts < Wavefront::Cli
 
   attr_accessor :options, :arguments
+
+  def parse_time(t)
+    return Time.at(t.to_i) if t.match(/^\d+$/)
+    begin
+      return DateTime.parse("#{t} #{Time.now.getlocal.zone}").to_time.utc
+    rescue
+      raise "cannot parse timestamp '#{t}'."
+    end
+  end
 
   def run
     raise 'Please supply a query.' if @arguments.empty?
@@ -47,11 +57,11 @@ class Wavefront::Cli::Ts < Wavefront::Cli
     options[:prefix_length] = @options[:prefixlength].to_i
 
     if @options[:start]
-      options[:start_time] = Time.at(@options[:start].to_i)
+      options[:start_time] = parse_time(@options[:start])
     end
 
     if @options[:end]
-      options[:end_time] = Time.at(@options[:end].to_i)
+      options[:end_time] = parse_time(@options[:end])
     end
 
     wave = Wavefront::Client.new(@options[:token], @options[:endpoint], @options[:debug])

--- a/lib/wavefront/cli/ts.rb
+++ b/lib/wavefront/cli/ts.rb
@@ -61,6 +61,8 @@ class Wavefront::Cli::Ts < Wavefront::Cli
       puts wave.query(query, granularity, options)
     when :graphite
       puts wave.query(query, granularity, options).graphite.to_json
+    when :human
+      puts wave.query(query, granularity, options).human
     else
       pp wave.query(query, granularity, options)
     end

--- a/lib/wavefront/cli/ts.rb
+++ b/lib/wavefront/cli/ts.rb
@@ -24,13 +24,14 @@ class Wavefront::Cli::Ts < Wavefront::Cli
 
   def run
     query = @arguments[0]
-    if @options.minutes?
+
+    if @options[:minutes]
       granularity = 'm'
-    elsif @options.hours?
+    elsif @options[:hours]
       granularity = 'h'
-    elsif @options.seconds?
+    elsif @options[:seconds]
       granularity = 's'
-    elsif @options.days?
+    elsif @options[:days]
       granularity = 'd'
     else
       puts "You must specify a granularity of either --seconds, --minutes --hours or --days. See --help for more information."

--- a/lib/wavefront/client.rb
+++ b/lib/wavefront/client.rb
@@ -62,12 +62,7 @@ module Wavefront
         args[:params].merge!(options[:passthru])
       end
 
-      begin
-        response = RestClient.get @base_uri.to_s, args
-      rescue
-        puts "ERROR: failed to make connection to endpoint.\n  (#{base_uri})"
-        exit 3
-      end
+      response = RestClient.get @base_uri.to_s, args
 
       klass = Object.const_get('Wavefront').const_get('Response').const_get(options[:response_format].to_s.capitalize)
       return klass.new(response, options)

--- a/lib/wavefront/client.rb
+++ b/lib/wavefront/client.rb
@@ -38,7 +38,7 @@ module Wavefront
 
     def query(query, granularity='m', options={})
 
-      options[:end_time] ||= Time.now
+      options[:end_time] ||= Time.now.utc
       options[:start_time] ||= options[:end_time] - DEFAULT_PERIOD_SECONDS
       options[:response_format] ||= DEFAULT_FORMAT
       options[:prefix_length] ||= DEFAULT_PREFIX_LENGTH

--- a/lib/wavefront/client.rb
+++ b/lib/wavefront/client.rb
@@ -65,7 +65,7 @@ module Wavefront
       begin
         response = RestClient.get @base_uri.to_s, args
       rescue
-        puts "ERROR: failed to make connection to endpoint (#{base_uri})"
+        puts "ERROR: failed to make connection to endpoint.\n  (#{base_uri})"
         exit 3
       end
 

--- a/lib/wavefront/client.rb
+++ b/lib/wavefront/client.rb
@@ -62,7 +62,12 @@ module Wavefront
         args[:params].merge!(options[:passthru])
       end
 
-      response = RestClient.get @base_uri.to_s, args
+      begin
+        response = RestClient.get @base_uri.to_s, args
+      rescue
+        puts "ERROR: failed to make connection to endpoint (#{base_uri})"
+        exit 3
+      end
 
       klass = Object.const_get('Wavefront').const_get('Response').const_get(options[:response_format].to_s.capitalize)
       return klass.new(response, options)
@@ -76,6 +81,5 @@ module Wavefront
         RestClient.log = 'stdout'
       end
     end
-
   end
 end

--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
   end
 end

--- a/lib/wavefront/constants.rb
+++ b/lib/wavefront/constants.rb
@@ -1,4 +1,4 @@
-=begin 
+=begin
     Copyright 2015 Wavefront Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ module Wavefront
     DEFAULT_PREFIX_LENGTH = 1
     DEFAULT_STRICT = true
     DEFAULT_OBSOLETE_METRICS = false
-    FORMATS = [ :raw, :ruby, :graphite, :highcharts ]
+    FORMATS = [ :raw, :ruby, :graphite, :highcharts, :human ]
     GRANULARITIES = %w( s m h d )
   end
 end

--- a/lib/wavefront/constants.rb
+++ b/lib/wavefront/constants.rb
@@ -23,6 +23,8 @@ module Wavefront
     DEFAULT_STRICT = true
     DEFAULT_OBSOLETE_METRICS = false
     FORMATS = [ :raw, :ruby, :graphite, :highcharts, :human ]
+    ALERT_FORMATS = [:ruby, :json, :human]
+    DEFAULT_ALERT_FORMAT = :human
     GRANULARITIES = %w( s m h d )
   end
 end

--- a/lib/wavefront/response.rb
+++ b/lib/wavefront/response.rb
@@ -120,20 +120,19 @@ module Wavefront
 
       def initialize(response, options={})
         super
+
         if self.respond_to?(:timeseries)
           out = ['%-20s%s' % ['query', self.query]]
 
           self.timeseries.each_with_index do |ts, i|
             out.<< '%-20s%s' % ['timeseries', i]
-            out += ts.map do |k, v|
-              next if k == 'data'
+            out += ts.select{|k,v| k != 'data' }.map do |k, v|
               if k == 'tags'
                 v.map { |tk, tv| 'tag.%-16s%s' % [tk, tv] }
               else
                 '%-20s%s' % [k, v]
               end
             end
-
             out += ts['data'].map do |t, v|
               [Time.at(t).strftime('%F %T'), v].join(' ')
             end

--- a/lib/wavefront/response.rb
+++ b/lib/wavefront/response.rb
@@ -120,23 +120,26 @@ module Wavefront
 
       def initialize(response, options={})
         super
-        out = ['%-20s%s' % ['query', self.query]]
+        if self.respond_to?(:timeseries)
+          out = ['%-20s%s' % ['query', self.query]]
 
-        self.timeseries.each_with_index do |ts, i|
-          out.<< '%-20s%s' % ['timeseries', i]
-          out += ts.map do |k, v|
-            next if k == 'data'
-            if k == 'tags'
-              v.map { |tk, tv| 'tag.%-16s%s' % [tk, tv] }
-            else
-              '%-20s%s' % [k, v]
+          self.timeseries.each_with_index do |ts, i|
+            out.<< '%-20s%s' % ['timeseries', i]
+            out += ts.map do |k, v|
+              next if k == 'data'
+              if k == 'tags'
+                v.map { |tk, tv| 'tag.%-16s%s' % [tk, tv] }
+              else
+                '%-20s%s' % [k, v]
+              end
+            end
+
+            out += ts['data'].map do |t, v|
+              [Time.at(t).strftime('%F %T'), v].join(' ')
             end
           end
-
-          out += ts['data'].map do |t, v|
-            [Time.at(t).strftime('%F %T'), v].join(' ')
-          end
-
+        else
+          out = self.warnings
         end
 
         @human = out

--- a/lib/wavefront/response.rb
+++ b/lib/wavefront/response.rb
@@ -1,4 +1,4 @@
-=begin 
+=begin
     Copyright 2015 Wavefront Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ module Wavefront
     class Ruby
       include JSON
       attr_reader :response, :options
-      
+
       def initialize(response, options={})
         @response = response
         @options = options
@@ -59,7 +59,7 @@ module Wavefront
       def initialize(response, options={})
         super
         options[:prefix_length] ||= Wavefront::Client::DEFAULT_PREFIX_LENGTH
-        
+
         @graphite = Array.new
         self.timeseries.each do |ts|
 
@@ -72,7 +72,7 @@ module Wavefront
           end
 
           output_timeseries['datapoints'] = datapoints
-          @graphite << output_timeseries 
+          @graphite << output_timeseries
 
         end
       end
@@ -111,5 +111,36 @@ module Wavefront
       end
     end
 
+    class Human < Wavefront::Response::Ruby
+      #
+      # Print "human-readable" (but also easily machine-pareseable)
+      # values.
+      #
+      attr_reader :response, :options, :human
+
+      def initialize(response, options={})
+        super
+        out = ['%-20s%s' % ['query', self.query]]
+
+        self.timeseries.each_with_index do |ts, i|
+          out.<< '%-20s%s' % ['timeseries', i]
+          out += ts.map do |k, v|
+            next if k == 'data'
+            if k == 'tags'
+              v.map { |tk, tv| 'tag.%-16s%s' % [tk, tv] }
+            else
+              '%-20s%s' % [k, v]
+            end
+          end
+
+          out += ts['data'].map do |t, v|
+            [Time.at(t).strftime('%F %T'), v].join(' ')
+          end
+
+        end
+
+        @human = out
+      end
+    end
   end
 end

--- a/lib/wavefront/response.rb
+++ b/lib/wavefront/response.rb
@@ -141,7 +141,7 @@ module Wavefront
           out = self.warnings
         end
 
-        @human = out
+        @human = out.join("\n")
       end
     end
   end

--- a/wavefront-client.gemspec
+++ b/wavefront-client.gemspec
@@ -1,4 +1,4 @@
-=begin 
+=begin
     Copyright 2015 Wavefront Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rest-client", ">= 1.6.7", "<= 1.8"
   spec.add_dependency "slop", ">= 3.4.7", "<= 3.6"
+  spec.add_dependency 'inifile',  '3.0.0'
   spec.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
 
 end


### PR DESCRIPTION
Give the CLI client the ability to read credentials, endpoints etc from an AWS-style config file. It allows you to easily switch between accounts with a `-P` option.

Allow time windows to be defined in any format which Ruby's `strparse()` can understand, rather than only in epoch seconds. (Epoch seconds still works as before.)

Add a "human" output format which makes it easy to inspect raw data. 

```
$ wavefront ts -P sysdef -f human --start 00:00 --end 00:02 -S 'ts("prod.www.host.network.global.net0.obytes64")'

query               ts("prod.www.host.network.global.net0.obytes64")
timeseries          0
label               prod.www.host.network.global.net0.obytes64
host                74a247a9-f67c-43ad-911f-fabafa9dc2f3joyent
tag.hostname        74a247a9-f67c-43ad-911f-fabafa9dc2f3joyent
2016-05-18 00:00:06 787420229.0
2016-05-18 00:00:16 787426313.0
2016-05-18 00:00:26 787431644.0
2016-05-18 00:00:36 787437780.0
2016-05-18 00:00:46 787443178.0
2016-05-18 00:00:56 787449331.0
2016-05-18 00:01:06 787454647.0
```

Also add "human" output to the alerts mode:

```
$ ./wavefront alerts -f human -s Ops snoozed
name                  Metric Rate Breach
created               2016-01-25 16:13:38 +0000
severity              SEVERE
condition             sum(rate(ts(~collector.points.valid))) > 50000
displayExpression     sum(rate(ts(~collector.points.valid)))
minutes               2
resolveAfterMinutes   30
updated               2016-05-18 13:02:55 +0100
alertStates           SNOOZED
metricsUsed           ~collector.points.valid
...
```

Add a `version` command. Improved error handling in a couple of places.