### PR TITLE
Fix/work from cron

### DIFF
--- a/bin/wavefront
+++ b/bin/wavefront
@@ -29,7 +29,16 @@ def sanitize_keys(hash)
 end
 
 ME = Pathname.new(__FILE__).basename
-DEF_CF = Pathname.new(ENV['HOME']) + '.wavefront'
+
+# If we are a normal user, look for wavefront config in our home
+# directory; if not, look in /etc
+#
+DEF_CF = if ENV['HOME']
+           Pathname.new(ENV['HOME']) + '.wavefront'
+         else
+           Pathname.new('/etc/wavefront/client.conf')
+         end
+
 
 # The global_opts are available in every command.
 #

--- a/bin/wavefront
+++ b/bin/wavefront
@@ -16,6 +16,7 @@
 
 require 'pathname'
 require 'wavefront/client'
+require 'wavefront/client/version'
 require 'wavefront/cli'
 require 'docopt'
 require 'socket'
@@ -156,7 +157,7 @@ Use '#{ME} <command> --help' for further information.)
 # help/option parser generation.
 #
 begin
-  opts = Docopt.docopt(usage[:default], version: '3.2.0')
+  opts = Docopt.docopt(usage[:default], version: Wavefront::Client::VERSION)
 rescue Docopt::Exit => e
   cmd = ARGV.length > 0 ? ARGV.first.to_sym : nil
 

--- a/lib/wavefront/cli/events.rb
+++ b/lib/wavefront/cli/events.rb
@@ -33,7 +33,12 @@ class Wavefront::Cli::Events < Wavefront::Cli
   include Wavefront::Mixins
 
   def run
-    @state_dir = EVENT_STATE_DIR + Etc.getlogin
+    begin
+      @state_dir = EVENT_STATE_DIR + Etc.getlogin
+    rescue
+      @state_dir = EVENT_STATE_DIR + 'notty'
+    end
+
     @hostname = Socket.gethostname
     @hosts = prep_hosts(options[:host])
     @t_start = prep_time(:start)

--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "3.3.0"
+    VERSION = "3.3.1"
   end
 end


### PR DESCRIPTION
The CLI could not create events when running in a non-standard environment. (cron job, SMF task). That's now fixed.

Also fixed an oversight where a version string was left hardcoded in.