### PR TITLE
no longer requires build tools to install

### DIFF
--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "3.3.1"
+    VERSION = "3.3.2"
   end
 end

--- a/wavefront-client.gemspec
+++ b/wavefront-client.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.version       = Wavefront::Client::VERSION
   spec.authors       = ["Sam Pointer", "Louis McCormack", "Joshua McGhee", "Conor Beverland", "Salil Deshmukh", "Rob Fisher"]
   spec.email         = ["support@wavefront.com"]
-  spec.description   = %q{A simple abstraction for talking to wavefront in ruby}
-  spec.summary       = %q{A simple abstraction for talking to wavefront in ruby}
+  spec.description   = %q{A simple abstraction for talking to Wavefront in Ruby. Includes a command-line interface.}
+  spec.summary       = %q{A simple abstraction for talking to Wavefront in Ruby}
   spec.homepage      = "https://github.com/wavefrontHQ/ruby-client"
   spec.license       = "Apache License 2.0"
 
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.5.0"
 
-  spec.add_dependency "rest-client", ">= 1.6.7", "<= 1.8"
+  spec.add_dependency "rest-client", ">= 1.6.7", "< 1.8"
   spec.add_dependency "docopt", "~> 0.5.0"
   spec.add_dependency 'inifile',  '3.0.0'
   spec.required_ruby_version = Gem::Requirement.new(">= 1.9.3")


### PR DESCRIPTION
The dependencies in the `gemspec` led `gem install wavefront-client` to pull in v1.8.0 of `rest-client`. This has a dependency on `http-cookie`, which depends on `domain_name`, which depends on `unf`, which depends on `unf-ext`, which requires a C-compiler and full build environment. This made it troublesome to install the gem on a minimally-configured production host. 

This patch specifies a version of `rest-client` without the `http-cookie` dependency, so our gem will install cleanly, anywhere.