### PR TITLE
Fix/remove webmock

### DIFF
--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "3.5.0"
+    VERSION = "3.5.1"
   end
 end

--- a/spec/wavefront/cli/sources_spec.rb
+++ b/spec/wavefront/cli/sources_spec.rb
@@ -1,5 +1,9 @@
+#
+# Due to dependency requirements, webmock does not work with Ruby
+# 1.9.3. For as long as we have to support that, it's off the table.
+#
 require 'spec_helper'
-require 'webmock/rspec'
+#require 'webmock/rspec'
 
 opts = {
   token: TEST_TOKEN,
@@ -19,19 +23,18 @@ describe Wavefront::Cli::Sources do
 
   end
 
-  describe '#list_source_handler' do
-    it 'makes API request with default options' do
-      stub_request(:get, "https://metrics.wavefront.com/api/manage/source/?desc=false&limit=100&pattern=mysource").
-      with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby', 'X-Auth-Token'=>'test'}).
-      to_return(:status => 200, :body => "{}", :headers => {})
-      wf.list_source_handler('mysource',)
+  #describe '#list_source_handler' do
+    #it 'makes API request with default options' do
+      #stub_request(:get, "https://metrics.wavefront.com/api/manage/source/?desc=false&limit=100&pattern=mysource").
+      #with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby', 'X-Auth-Token'=>'test'}).
+      #to_return(:status => 200, :body => "{}", :headers => {})
+      #wf.list_source_handler('mysource',)
       #expect(wf).to receive(:display_data).with('list_source', '')
-    end
+    #end
 
     #it 'handles an invalid source' do
       #expect{wf.show_source('!INVALID!')}.
         #to raise_exception(Wavefront::Exception::InvalidSource)
     #end
-  end
-
+  #end
 end

--- a/wavefront-client.gemspec
+++ b/wavefront-client.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.5.0"
   spec.add_development_dependency 'yard',  '~> 0.9.5'
-  spec.add_development_dependency 'webmock', '~> 2.1.0'
 
   spec.add_dependency "rest-client", ">= 1.6.7", "< 1.8"
   spec.add_dependency "docopt", "~> 0.5.0"


### PR DESCRIPTION
we can't have webmock tests for as long as we support Ruby 1.9.3. :(