### PR TITLE
Fix/missing mixins

### DIFF
--- a/lib/wavefront/cli/sources.rb
+++ b/lib/wavefront/cli/sources.rb
@@ -54,7 +54,7 @@ class Wavefront::Cli::Sources < Wavefront::Cli
 
     q[:lastEntityId] = start if start
 
-    display_data(JSON.parse(wf.show_sources(q)), 'list_source')
+    display_data(wf.show_sources(q), 'list_source')
   end
 
   def describe_handler(hosts, desc)
@@ -113,7 +113,7 @@ class Wavefront::Cli::Sources < Wavefront::Cli
   def show_source_handler(sources)
     sources.each do |s|
       begin
-        result = JSON.parse(wf.show_source(s))
+        result = wf.show_source(s)
       rescue RestClient::ResourceNotFound
         puts "Source '#{s}' not found."
         next

--- a/lib/wavefront/client/version.rb
+++ b/lib/wavefront/client/version.rb
@@ -16,6 +16,6 @@ See the License for the specific language governing permissions and
 
 module Wavefront
   class Client
-    VERSION = "3.5.1"
+    VERSION = "3.5.2"
   end
 end

--- a/lib/wavefront/metadata.rb
+++ b/lib/wavefront/metadata.rb
@@ -120,9 +120,12 @@ module Wavefront
 
     def show_sources(params = {})
       #
-      # return a list of sources. Maps to
+      # Return a list of sources as a Ruby object. Maps to
       # GET /api/manage/source
       # call it with a hash as described in the Wavefront API docs.
+      #
+      # See the Wavefront API docs for the format of the returned
+      # object.
       #
       # At the time of writing, supported paramaters are:
       #   lastEntityId (string)
@@ -153,16 +156,18 @@ module Wavefront
         end
       end
 
-      call_get(build_uri(nil, query: hash_to_qs(params)))
+      JSON.parse(call_get(build_uri(nil, query: hash_to_qs(params))))
     end
 
     def show_source(source)
       #
-      # return information about a single source. Maps to
-      # GET /api/manage/source/{source}
+      # return information about a single source as a Ruby object. Maps to
+      # GET /api/manage/source/{source}.
+      #
+      # See the Wavefront API docs for the structure of the object.
       #
       fail Wavefront::Exception::InvalidSource unless valid_source?(source)
-      call_get(build_uri(source))
+      JSON.parse(call_get(build_uri(source)))
     end
 
     def set_description(source, desc)

--- a/lib/wavefront/metadata.rb
+++ b/lib/wavefront/metadata.rb
@@ -18,6 +18,7 @@ require "wavefront/client/version"
 require "wavefront/constants"
 require "wavefront/exception"
 require 'wavefront/validators'
+require 'wavefront/mixins'
 require 'rest_client'
 require 'uri'
 require 'logger'

--- a/spec/wavefront/metadata_spec.rb
+++ b/spec/wavefront/metadata_spec.rb
@@ -90,6 +90,7 @@ describe Wavefront::Metadata do
       expect(RestClient).to receive(:get).with(
         concat_url(host, path, '?'), wf.headers
       )
+      expect(JSON).to receive(:parse)
       wf.show_sources
     end
 
@@ -97,6 +98,7 @@ describe Wavefront::Metadata do
       expect(RestClient).to receive(:get).with(
         concat_url(host, path, '?limit=100&pattern=test-*'), wf.headers
       )
+      expect(JSON).to receive(:parse)
       wf.show_sources({ limit: 100, pattern: 'test-*' })
     end
 
@@ -132,6 +134,7 @@ describe Wavefront::Metadata do
       expect(RestClient).to receive(:get).with(
         concat_url(host, path, 'mysource'), wf.headers
       )
+      expect(JSON).to receive(:parse)
       wf.show_source('mysource')
     end
 


### PR DESCRIPTION
Mixins weren't being automatically pulled in by `require 'metadata'`. A very minor annoyance, but fixed here.

I've also put in a fix for the wrong type of date being returned from two methods in the metadata class.