### PR TITLE
fix sources endpoint bug and add verbosity

### DIFF
--- a/bin/wavefront
+++ b/bin/wavefront
@@ -46,6 +46,7 @@ Global options:
   -c, --config=FILE    path to configuration file [default: #{DEF_CF}]
   -P, --profile=NAME   profile in configuration file [default: default]
   -D, --debug          enable debug mode
+  -V, --verbose        be verbose
   -h, --help           show this message
 )
 
@@ -55,7 +56,7 @@ Global options:
 usage = {
 ts: %(
 Usage:
-  #{ME} ts [-c file] [-P profile] [-E endpoint] [-t token] [-OD]
+  #{ME} ts [-c file] [-P profile] [-E endpoint] [-t token] [-ODV]
             [-S | -m | -H | -d] [-s time] [-e time] [-f format] [-p num]
             [-X bool] <query>
 #{global_opts}
@@ -81,7 +82,7 @@ Options:
 
 alerts: %(
 Usage:
-  #{ME} alerts [-c file] [-P profile] [-E endpoint] [-t token]
+  #{ME} alerts [-c file] [-P profile] [-E endpoint] [-t token] [-V]
             [-f format] [-p tag] [ -s tag] <state>
 #{global_opts}
 Options:
@@ -108,7 +109,6 @@ Usage:
 #{global_opts}
 Options:
   -i, --instant        create an instantaneous event
-  -V, --verbose        be verbose
   -s, --start=TIME     time at which event begins
   -e, --end=TIME       time at which event ends
   -l, --level=LEVEL    level of event (#{EVENT_LEVELS.join(', ')})
@@ -139,7 +139,6 @@ Options:
   -m, --metric=STRING  the metric path to which contents of a file will be
                        assigned. If the file contains a metric name, the two
                        will be concatenated
-  -V, --verbose        be verbose
 
 Files are whitespace separated, and fields can be defined with the -F
 option.  Use 't' for timestamp; 'm' for metric name; 'v' for value
@@ -147,19 +146,19 @@ and 'T' for tags. Put 'T' last.
 ),
 source: %(
 Usage:
-  #{ME} source list [-c file] [-P profile] [-E endpoint] [-t token]
+  #{ME} source list [-c file] [-P profile] [-E endpoint] [-t token] [-V]
            [-f format] [-T tag ...] [-at] [-s source] [-l limit] <pattern>
-  #{ME} source show [-c file] [-P profile] [-E endpoint] [-t token]
+  #{ME} source show [-c file] [-P profile] [-E endpoint] [-t token] [-V]
            [-f format] <host> ...
   #{ME} source describe [-c file] [-P profile] [-E endpoint] [-t token]
-           [-H host ... ] <description>
+           [-V] [-H host ... ] <description>
   #{ME} source undescribe [-c file] [-P profile] [-E endpoint] [-t token]
-           [<host>] ...
+           [-V] [<host>] ...
   #{ME} source tag add [-c file] [-P profile] [-E endpoint] [-t token]
-           [-H host ... ] <tag> ...
+           [-V] [-H host ... ] <tag> ...
   #{ME} source tag delete [-c file] [-P profile] [-E endpoint] [-t token]
-           [-H host ... ] <tag> ...
-  #{ME} source untag [-c file] [-P profile] [-E endpoint] [-t token]
+           [-V] [-H host ... ] <tag> ...
+  #{ME} source untag [-c file] [-P profile] [-E endpoint] [-t token] [-V]
            [<host>] ...
   #{ME} source --help
 #{global_opts}

--- a/lib/wavefront/cli/sources.rb
+++ b/lib/wavefront/cli/sources.rb
@@ -10,7 +10,8 @@ class Wavefront::Cli::Sources < Wavefront::Cli
   attr_accessor :wf, :out_format, :show_hidden, :show_tags
 
   def setup_wf
-    @wf = Wavefront::Metadata.new(options[:token])
+    @wf = Wavefront::Metadata.new(options[:token], options[:endpoint],
+                                 false, { verbose: options[:verbose] })
   end
 
   def run

--- a/lib/wavefront/metadata.rb
+++ b/lib/wavefront/metadata.rb
@@ -40,14 +40,16 @@ module Wavefront
     include Wavefront::Validators
     DEFAULT_PATH = '/api/manage/source/'.freeze
 
-    attr_reader :headers, :host
+    attr_reader :headers, :host, :verbose, :endpoint
 
-    def initialize(token, host=DEFAULT_HOST, debug=false)
+    def initialize(token, host=DEFAULT_HOST, debug=false, options = {})
       #
       # 'host' is the Wavefront API endpoint
       #
       @headers = {'X-AUTH-TOKEN' => token}
       @base_uri = URI::HTTPS.build(:host => host, :path => DEFAULT_PATH)
+      @endpoint = host
+      @verbose = options[:verbose] || false
       debug(debug)
     end
 
@@ -193,7 +195,7 @@ module Wavefront
     private
 
     def build_uri(path_ext = '', options = {})
-      options[:host] ||= DEFAULT_HOST
+      options[:host] ||= endpoint
       options[:path] ||= DEFAULT_PATH
 
       URI::HTTPS.build(
@@ -204,14 +206,17 @@ module Wavefront
     end
 
     def call_get(uri)
+      puts "GET #{uri.to_s}" if verbose
       RestClient.get(uri.to_s, headers)
     end
 
     def call_delete(uri)
+      puts "DELETE #{uri.to_s}" if verbose
       RestClient.delete(uri.to_s, headers)
     end
 
     def call_post(uri, query = nil)
+      puts "POST #{uri.to_s} #{query}" if verbose
       h = headers
 
       RestClient.post(uri.to_s, query,


### PR DESCRIPTION
This fixes a bug in the metadata SDK class, which made it unnecessarily hard to use an API endpoint other than 'metrics.wavefront.com'. 

I've also made the `-V` option valid in all CLI subcommands, even though in some cases it doesn't do anything.